### PR TITLE
feat: add typebot manifest

### DIFF
--- a/app/typebot/manifest.yml
+++ b/app/typebot/manifest.yml
@@ -1,0 +1,13 @@
+manifestVersion: v1
+slugs:
+  - typebot
+name: Typebot
+type: app
+description: Typebot is a powerful open-source chatbot builder that you can self-host. Create advanced conversational forms and chatbots with 34+ building blocks including text, images, videos, conditional logic, webhooks, OpenAI integration, and more.
+registryImageAddress: docker.io/goinfinite/os:latest
+launchScript:
+  - os mktplace install --slug typebot --data-fields 'adminMailAddress:%randomMail%' --data-fields 'builderSubdomain:builder' --data-fields 'smtpHost:smtp.example.com' --data-fields 'smtpPort:587' --data-fields 'smtpUsername:noreply@example.com' --data-fields 'smtpPassword:%randomPassword%' --data-fields 'smtpFrom:%randomMail%'
+minimumCpuMillicores: 4000
+minimumMemoryBytes: 8589934592
+estimatedSizeBytes: 6147702683
+avatarUrl: https://goinfinite.github.io/os-marketplace/app/typebot/assets/avatar.png


### PR DESCRIPTION
- Added Typebot app manifest with OS Marketplace integration
- Includes launchScript with data fields configuration
- Set minimum requirements: 4 vCPU, 8 GiB RAM
- Uses docker.io/goinfinite/os:latest registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Typebot app manifest configuration with Docker image reference, resource specifications (4000 millicores CPU, 8GB memory minimum), and configurable installation parameters for SMTP and admin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->